### PR TITLE
Fix for private keys hosted locally.

### DIFF
--- a/src/web/js/keybaseAPI.js
+++ b/src/web/js/keybaseAPI.js
@@ -315,10 +315,11 @@ class KeybaseAPI {
   static getPrivateManager() {
     return new Promise(function(resolve, reject) {
       var me = JSON.parse(localStorage.getItem('keybase'));
-      if (!me) {
-        reject('Nothing stored in local storage for me.');
+      if (!me.private_keys.primary) {
+        reject('Cannot decrypt: PGP private key is not available in Keybase\'s encrypted key store.');
         return;
       }
+      console.log(me);
       var bundle = me.private_keys.primary.bundle;
       var passphrase = localStorage.getItem('keybasePassphrase');
       p3skb.p3skbToArmoredPrivateKey(bundle, passphrase)


### PR DESCRIPTION
Small fix to give better error handling for when a user doesn't have their PGP key stored with Keybase.

FROM: 
![image](https://cloud.githubusercontent.com/assets/273880/25683264/f6e9e870-3020-11e7-9d96-25de39f77336.png)
TO:
![image](https://cloud.githubusercontent.com/assets/273880/25690952/06612a6c-305c-11e7-9550-15be717a7131.png)

Similar to this page on keybase.io/decrypt
![image](https://cloud.githubusercontent.com/assets/273880/25683240/e13a98c6-3020-11e7-80b7-d404dc745144.png)
