### PR TITLE
Show navbar when loading mail client

### DIFF
--- a/src/web/views/mail.ejs
+++ b/src/web/views/mail.ejs
@@ -34,6 +34,16 @@
 </head>
 <body>
   <div id="app">
+    <nav class="navbar navbar-default">
+      <div class="container-fluid">
+        <div class="navbar-header">
+          <a class="navbar-brand">
+            <img id="navbar-logo" src="logo-transparent-no-text.png"/>
+            Confidante
+          </a>
+        </div>
+      </div>
+    </nav>
     <div class="container">
       <div class="preload">
         <div class="large-spinner"></div>


### PR DESCRIPTION
Render the navbar on the inbox loading screen before the javascript bundle loads in, so that the transition is less abrupt when the React app appears. 

What it looks like in this PR:
<img width="600" alt="screen shot 2017-08-25 at 12 22 39 am" src="https://user-images.githubusercontent.com/2206755/29703721-a78733aa-892b-11e7-96d8-6a0852b13a7a.png">
